### PR TITLE
Validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ var bytes = uuid.parse('797ff043-11eb-11e1-80d6-510998755d10'); // -> <Buffer 79
 var string = uuid.unparse(bytes); // -> '797ff043-11eb-11e1-80d6-510998755d10'
 ```
 
+### uuid.validate(str)
+
+Check whether a given string is a valid UUID
+
+  * `str` - (String) UUID(-like) string
+
+```javascript
+uuid.validate('797ff043-11eb-11e1-80d6-510998755d10'); // -> true
+uuid.validate('some-invalid-uuid-1234567890-1234567'); // -> false
+```
+
 ### uuid.noConflict()
 
 (Browsers only) Set `uuid` property back to it's previous value.

--- a/test/test.js
+++ b/test/test.js
@@ -117,6 +117,13 @@ var dt = parseInt(after, 16) - parseInt(before, 16);
 assert(dt === 1, 'Ids spanning 1ms boundary are 100ns apart');
 
 //
+// Test validate
+//
+
+assert(uuid.validate('d9428888-122b-11e1-b85c-61cd3cbb3210') === true, 'Valid uuid');
+assert(uuid.validate('d9428888-11e1-b85c-61cd3cbb3210') === false, 'Invalid uuid');
+
+//
 // Test parse/unparse
 //
 

--- a/uuid.js
+++ b/uuid.js
@@ -91,6 +91,11 @@
             bth[buf[i++]] + bth[buf[i++]];
   }
 
+  // **`validate(str)` - Test whether given string a valid UUID**
+  function validate(str) {
+    return /[0-9a-f]{22}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.test(str);
+  }
+
   // **`v1()` - Generate time-based UUID**
   //
   // Inspired by https://github.com/LiosK/UUID.js
@@ -222,6 +227,7 @@
   uuid.v4 = v4;
   uuid.parse = parse;
   uuid.unparse = unparse;
+  uuid.validate = validate;
   uuid.BufferClass = BufferClass;
 
   if (typeof define === 'function' && define.amd) {


### PR DESCRIPTION
Adds a `uuid.validate(str)` method; derived from the comments in https://github.com/broofa/node-uuid/issues/41