### PR TITLE
Force to _hexToByte to be fast V8 object

### DIFF
--- a/uuid.js
+++ b/uuid.js
@@ -59,6 +59,16 @@
     _hexToByte[_byteToHex[i]] = i;
   }
 
+  // Force _hexToByte to be changed to fast-property object in V8
+  (function toFastProperties(obj) {
+    /*jshint -W027*/
+    function f() {}
+    f.prototype = obj;
+    return f;
+    eval(obj);
+  }(_hexToByte));
+
+
   // **`parse()` - Parse a UUID into it's component bytes**
   function parse(s, buf, offset) {
     var i = (buf && offset) || 0, ii = 0;


### PR DESCRIPTION
This change results in:
```
C:\Users\michal.wadas\Documents\GitHub\node-uuid\uuid.js:159
      throw new Error('uuid.v1(): Can\'t create more than 10M uuids/sec');
```
on my computer.