### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,5 @@
   "main"          : "./uuid.js",
   "repository"    : { "type" : "git", "url" : "https://github.com/broofa/node-uuid.git" },
   "version"       : "1.4.2",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.github.com/broofa/node-uuid/master/LICENSE.md"
-    }
-  ]
+  "license"       : "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/