### PR TITLE
add coverage reporting using the nyc bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .DS_Store
+.nyc_output
+coverage

--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
     "uuid": "./bin/uuid"
   },
   "scripts": {
-    "test": "node test/test.js"
+    "test": "node test/test.js",
+    "coverage": "nyc npm test && nyc report"
   },
   "lib"           : ".",
   "main"          : "./uuid.js",
   "repository"    : { "type" : "git", "url" : "https://github.com/broofa/node-uuid.git" },
   "version"       : "1.4.2",
-  "license"       : "MIT"
+  "license"       : "MIT",
+  "devDependencies": { "nyc": "^2.2.0" }
+
 }


### PR DESCRIPTION
This pull request adds coverage reporting using [nyc](https://www.npmjs.com/package/nyc):

* run `npm run coverage` to get a human readable coverage report.
* run `npm run coverage -- --reporter=lcov` to get an HTML report over coverage in the /coverage folder.

Here's the current state of things:

```shell
--------------|-----------|-----------|-----------|-----------|
File          |   % Stmts |% Branches |   % Funcs |   % Lines |
--------------|-----------|-----------|-----------|-----------|
   ./         |     85.05 |     82.28 |     63.64 |     86.54 |
      uuid.js |     85.05 |     82.28 |     63.64 |     86.54 |
--------------|-----------|-----------|-----------|-----------|
All files     |     85.05 |     82.28 |     63.64 |     86.54 |
--------------|-----------|-----------|-----------|-----------|
```