### PR TITLE
Don't try to load the node package in a browser

### DIFF
--- a/uuid.js
+++ b/uuid.js
@@ -18,7 +18,7 @@
   // Node.js crypto-based RNG - http://nodejs.org/docs/v0.6.2/api/crypto.html
   //
   // Moderately fast, high quality
-  if ('function' === typeof require) {
+  if ('undefined' === typeof window && 'function' === typeof require) {
     try {
       var _rb = require('crypto').randomBytes;
       _nodeRNG = _rng = _rb && function() {return _rb(16);};


### PR DESCRIPTION
This PR fixes an issue we observed with the latest version of node-uuid where it caused crypto-browserify to throw error below when using in a Webpack/Babel environment when trying to run our tests in PhantomJS using Karma.

```
TYPE_MISMATCH_ERR: DOM Exception 17: The type of an object was incompatible with the expected type of
the parameter associated to the object.
```