### PR TITLE
Memory issues around creating id - solution

### DIFF
--- a/lib/bytesToUuid.js
+++ b/lib/bytesToUuid.js
@@ -10,14 +10,14 @@ for (var i = 0; i < 256; ++i) {
 function bytesToUuid(buf, offset) {
   var i = offset || 0;
   var bth = byteToHex;
-  return  bth[buf[i++]] + bth[buf[i++]] +
-          bth[buf[i++]] + bth[buf[i++]] + '-' +
-          bth[buf[i++]] + bth[buf[i++]] + '-' +
-          bth[buf[i++]] + bth[buf[i++]] + '-' +
-          bth[buf[i++]] + bth[buf[i++]] + '-' +
-          bth[buf[i++]] + bth[buf[i++]] +
-          bth[buf[i++]] + bth[buf[i++]] +
-          bth[buf[i++]] + bth[buf[i++]];
+  return ([bth[buf[i++]], bth[buf[i++]], 
+	bth[buf[i++]], bth[buf[i++]], '-',
+	bth[buf[i++]], bth[buf[i++]], '-',
+	bth[buf[i++]], bth[buf[i++]], '-',
+	bth[buf[i++]], bth[buf[i++]], '-',
+	bth[buf[i++]], bth[buf[i++]],
+	bth[buf[i++]], bth[buf[i++]],
+	bth[buf[i++]], bth[buf[i++]]]).join('');
 }
 
 module.exports = bytesToUuid;


### PR DESCRIPTION
Currently, whenever we create an id, we are allocating 600 bytes of memory for each id.
This is because chromium has a bug that does not allow using the '+' operator to allocate memory correctly: https://bugs.chromium.org/p/v8/issues/detail?id=2869

Changing this to a join will fix the size difference:

Concatenate: Shallow Size 40, Retained Size 600
Join: Shallow Size: 64, Retained Size: 64